### PR TITLE
Add Hotspot Game link to homepage menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -508,6 +508,9 @@
                     <a href="news.html" class="nav-link">资讯动态</a>
                 </li>
                 <li class="nav-item">
+                    <a href="https://hotspotgame.online/" class="nav-link" target="_blank" rel="noopener noreferrer">热点游戏</a>
+                </li>
+                <li class="nav-item">
                     <a href="about.html" class="nav-link">关于我们</a>
                 </li>
             </ul>


### PR DESCRIPTION
## Summary
- add a Hotspot Game navigation item on the homepage pointing to https://hotspotgame.online/

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0c2bd3e708321a513f835c9d03b59